### PR TITLE
Enhance simulation UI and bot logic

### DIFF
--- a/grid.py
+++ b/grid.py
@@ -31,13 +31,17 @@ class Grid:
             return self.cells[x][y]
         return None
 
-    def find_empty_storage_cell(self) -> Optional[Cell]:
-        """Return first storage cell with spare capacity or None."""
+    def find_empty_storage_cell(self, exclude: Optional[set[Cell]] = None) -> Optional[Cell]:
+        """Return a random storage cell with spare capacity, excluding any provided."""
+        import random
+        if exclude is None:
+            exclude = set()
+        candidates: list[Cell] = []
         for col in self.cells:
             for cell in col:
-                if cell.type == "storage" and len(cell.items) < config.MAX_ITEMS_PER_CELL:
-                    return cell
-        return None
+                if cell.type == "storage" and len(cell.items) < config.MAX_ITEMS_PER_CELL and cell not in exclude:
+                    candidates.append(cell)
+        return random.choice(candidates) if candidates else None
 
     def find_item(self, code: str) -> Tuple[Optional[Cell], Optional[object]]:
         """Locate an item by code; search storage+inbound."""

--- a/state.py
+++ b/state.py
@@ -1,6 +1,10 @@
 class SimulationState:
     # 모드/플래그
     auto_mode = True
+    auto_inbound = False
+    auto_outbound = False
+    auto_in_count = 0
+    auto_out_count = 0
     awaiting_inbound_input = None
     request_add_bot = False
     request_remove_bot = False


### PR DESCRIPTION
## Summary
- randomize storage selection to distribute bot activity
- track automatic inbound and outbound counts
- support item-specific pickups and realistic re-sorting
- add manual outbound request button
- show auto in/out status with counters

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68540ee4d6e4832691deca98b15232e4